### PR TITLE
Refactor: use just one map layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,11 +29,6 @@
                 <button>ETIC 2</button>
             </div>
         </div>
-
-        <!-- Map container for Leaflet -->
-        <div class="map-layer">
-            <div id="map" class="map"></div>
-        </div>
     </div>
     
     <!-- ROUTE SELECTION SCREEN -->
@@ -131,11 +126,6 @@
 
         <!-- Start button -->
         <button class="start-button screen-selector" id="start-button" data-target="navigation-screen">Start</button>
-
-        <!-- Map container for Leaflet -->
-        <div class="map-layer">
-            <div id="map" class="map"></div>
-        </div>
     </div>
 
 
@@ -176,13 +166,13 @@
             </div>
         </div>
 
-        <!-- Map container for Leaflet -->
-        <div class="map-layer">
-            <div id="map" class="map"></div>
-        </div>
-
         <!-- Exit button -->
         <button class="exit-button screen-selector" id="exit-button" data-target="searching-screen">Exit Navigation</button>
+    </div>
+
+    <!-- Map container for Leaflet -->
+    <div class="map-layer">
+        <div id="map" class="map"></div>
     </div>
 
     <!-- Leaflet JS -->

--- a/script.js
+++ b/script.js
@@ -19,8 +19,6 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
     });
-
-
 });
 
 // ---------------- Leaflet map ----------------
@@ -64,47 +62,3 @@ locations.forEach(loc => {
         .addTo(map)
         .bindPopup(loc.name);
 });
-
-// ---------------- Adjust minZoom to fully fill screen ----------------
-function updateMinZoom() {
-    const mapSize = map.getSize();
-    const zoomX = mapSize.x / width;
-    const zoomY = mapSize.y / height;
-    const scale = Math.min(zoomX, zoomY);
-
-    // Compute theoretical zoom, then clamp it between your allowed min/max
-    const computedZoom = map.getScaleZoom(scale);
-
-    // Clamp zoom so it doesn’t go beyond the valid range
-    const minZoom = Math.max(computedZoom, 0);
-    const maxZoom = 2;
-
-    map.setMinZoom(minZoom);
-    map.setMaxZoom(maxZoom);
-
-    // Keep the view fitting within bounds
-    map.fitBounds(bounds);
-
-    // Optional: stay slightly zoomed in for aesthetics
-    map.setZoom(minZoom + 1);
-}
-
-
-// every time the screen changes size or is reloaded, the map must recalculate its max and min sizes
-window.addEventListener('load', () => {
-    map.invalidateSize();
-});
-let resizeTimer;
-window.addEventListener('resize', () => {
-    clearTimeout(resizeTimer);
-    resizeTimer = setTimeout(() => {
-        map.invalidateSize();
-    }, 150); // only fires 150ms after resizing stops
-});
-
-// Run once after map loads
-updateMinZoom();
-
-// Optional: adjust on window resize
-window.addEventListener('resize', updateMinZoom);
-


### PR DESCRIPTION
Makes it so that all screens use the same map layer. I think this is going to simplify the code for #10.